### PR TITLE
Correct Typo in add firmware migration script

### DIFF
--- a/Server/bkr/server/alembic/versions/2a56e56fbe26_add_firmware_info_to_system_table.py
+++ b/Server/bkr/server/alembic/versions/2a56e56fbe26_add_firmware_info_to_system_table.py
@@ -22,8 +22,8 @@ from sqlalchemy import Column, String, DateTime
 def upgrade():
     op.add_column('system', Column('sysfw_version', String(32), nullable=True))
     op.add_column('system', Column('sysfw_date', DateTime, nullable=True))
-    op.add_column('device', Column('fw_version', String(32), mullable=True))
-    op.add_column('device', Column('fw_date', DateTime, mullable=True))
+    op.add_column('device', Column('fw_version', String(32), nullable=True))
+    op.add_column('device', Column('fw_date', DateTime, nullable=True))
     # TODO: I think we also need to play with the table constraints for the
     # device table as well but I am not sure specifically what is needed
     # right now


### PR DESCRIPTION
mullable should be nullable in lines 25 & 26

Change-Id: I4809eae33b4db745a919f4a8625534516ce1d835
Signed-off-by: Shawn Doherty <sdoherty@redhat.com>